### PR TITLE
Fixes problem with multiple keys

### DIFF
--- a/src/Frame/Response/Foundation.php
+++ b/src/Frame/Response/Foundation.php
@@ -137,7 +137,7 @@ abstract class Foundation
         }
 
         if (isset($_SESSION['FRAME.flash'])) {
-            $flash = json_decode($_SESSION['FRAME.flash']);
+            $flash = json_decode($_SESSION['FRAME.flash'], true);
         } else {
             $flash = [];
         }

--- a/tests/Frame/Tests/ResponseTest.php
+++ b/tests/Frame/Tests/ResponseTest.php
@@ -2,8 +2,23 @@
 
 namespace Frame\Tests;
 
+use Frame\Request\Request;
+
 class ResponseTest extends \PHPUnit_Framework_TestCase
 {
+    public function testFlashWithMultipleKeys()
+    {
+        $project = new \Frame\Core\Project(__NAMESPACE__, 'tests', true);
+        $ctx = new \Frame\Core\Context($project);
+        $response = new \Frame\Response\Response($ctx);
+
+        $response->flash('first_key', 'first_value');
+        $response->flash('second_key', 'second_value');
+
+        $request = new Request($ctx);
+        $this->assertEquals('first_value', $request->getFlash('first_key'));
+        $this->assertEquals('second_value', $request->getFlash('second_key'));
+    }
 
     public function testResponseInterface()
     {


### PR DESCRIPTION
If second parameter is not set to true in json_decode it will decode it as an object and will always overwrite it when a second flash happens.
